### PR TITLE
Add the content-type header to curl examples

### DIFF
--- a/docs/source/inference.rst
+++ b/docs/source/inference.rst
@@ -52,6 +52,7 @@ If you want to hit the API endpoint directly, you can use ``curl``. Here is an e
    curl \
      --request POST \
      --header "Authorization: Bearer ${LLM_OPERATOR_TOKEN}" \
+     --header "Content-Type: application/json" \
      --data '{"model": "google-gemma-2b-it-q4", "messages": [{"role": "user", "content": "What is k8s?"}]}' \
      http://localhost:8080/v1/chat/completions
 

--- a/docs/source/rag.rst
+++ b/docs/source/rag.rst
@@ -80,6 +80,7 @@ If you want to hit the API endpoint directly, you can use ``curl``. Here is an e
    curl \
      --request POST \
      --header "Authorization: Bearer ${LLM_OPERATOR_TOKEN}" \
+     --header "Content-Type: application/json" \
      --data '{
       "model": "google-gemma-2b-it-q4",
       "messages": [{"role": "user", "content": "What is LLM Operator?"}],

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -153,11 +153,13 @@ The first option is to use the CLI. Here are examle commands:
 
    curl \
      --header "Authorization: Bearer ${LLM_OPERATOR_TOKEN}" \
+     --header "Content-Type: application/json" \
      http://localhost:8080/v1/models | jq
 
    curl \
      --request POST \
      --header "Authorization: Bearer ${LLM_OPERATOR_TOKEN}" \
+     --header "Content-Type: application/json" \
      --data '{"model": "google-gemma-2b-it-q4", "messages": [{"role": "user", "content": "What is k8s?"}]}' \
      http://localhost:8080/v1/chat/completions
 


### PR DESCRIPTION
vLLM doesn't accept a request with the header
(https://github.com/vllm-project/vllm/issues/5440).